### PR TITLE
Update index.html computer_organisation href updated to correct one

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ margin: 0 auto;
 <heading>Teaching</heading>
 
 <p> Spring 2024- CST310 Computer Graphics <a href="https://sadbhawnathakur.github.io/computer_graphics.html">Course Website</a> </p>
-<p> Spring 2024- CS Computer Organization and Architecture <a href="https://sadbhawnathakur.github.io/computer_organization_and__architecture.html">Course Website</a> </p>
+<p> Spring 2024- CS Computer Organization and Architecture <a href="https://sadbhawnathakur.github.io/computer_organization_and_architecture.html">Course Website</a> </p>
 <p> Fall 2024- CST437 Neural Networks <a href="https://sadbhawnathakur.github.io/neural_networks.html">Course Website</a> </p>
 <p> Fall 2024- 22CST101 Programming with Python <a href="https://sadbhawnathakur.github.io/python_programming.html">Course Website</a> </p>
 


### PR DESCRIPTION
the href for computer organization and architecture is syntactically wrong (there are 2 underscores(__) ) corrected it